### PR TITLE
AST-based tests

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -3,5 +3,13 @@
   "testEnvironment": "node",
   "collectCoverage": true,
   "passWithNoTests": true,
-  "testMatch": ["**/__tests__/**/*.ts?(x)", "**/?(*.)+(spec|test|tests).ts?(x)"]
+  "transformIgnorePatterns": ["/node_modules/(?!@basketry/jest-utils)"],
+  "setupFilesAfterEnv": ["@basketry/jest-utils/lib/setup"],
+  "testMatch": [
+    "**/__tests__/**/*.ts?(x)",
+    "**/?(*.)+(spec|test|tests).ts?(x)"
+  ],
+  "moduleNameMapper": {
+    "^@basketry/jest-utils$": "<rootDir>/utils/jest-utils/src"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,14 @@
     "": {
       "name": "@basketry/typescript-monorepo",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
-        "packages/*"
+        "packages/*",
+        "utils/*"
       ],
       "devDependencies": {
+        "@prettier/sync": "^0.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.21",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
@@ -576,6 +579,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@basketry/jest-utils": {
+      "resolved": "utils/jest-utils",
+      "link": true
     },
     "node_modules/@basketry/typescript": {
       "resolved": "packages/typescript",
@@ -1728,6 +1735,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@prettier/sync": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.6.1.tgz",
+      "integrity": "sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==",
+      "dev": true,
+      "dependencies": {
+        "make-synchronized": "^0.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
+      },
+      "peerDependencies": {
+        "prettier": "*"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -6998,6 +7020,15 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
+    "node_modules/make-synchronized": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.8.0.tgz",
+      "integrity": "sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fisker/make-synchronized?sponsor=1"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9046,6 +9077,11 @@
       "funding": {
         "url": "https://github.com/sponsors/basketry"
       }
+    },
+    "utils/jest-utils": {
+      "name": "@basketry/jest-utils",
+      "version": "0.0.0",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Monorepo for all Basketry Typescript packages",
   "private": true,
   "scripts": {
-    "prebuild": "npm run clean --workspaces --if-present",
     "build": "run-s build:*",
     "build:typescript": "npm run build --workspace @basketry/typescript",
     "build:typescript-dtos": "npm run build --workspace @basketry/typescript-dtos",
@@ -17,6 +16,7 @@
     "lint": "run-s -s lint:*",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier -c . --ignore-path .gitignore",
+    "postinstall": "npm run build --workspace @basketry/jest-utils",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ./node_modules/.bin/jest"
   },
   "author": "Steve Konves",
@@ -31,6 +31,7 @@
   "homepage": "https://basketry.io/docs/components/@basketry/typescript",
   "funding": "https://github.com/sponsors/basketry",
   "devDependencies": {
+    "@prettier/sync": "^0.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.21",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
@@ -47,6 +48,7 @@
     "typescript": "^5.8.3"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "utils/*"
   ]
 }

--- a/packages/zod/src/schema-file.ts
+++ b/packages/zod/src/schema-file.ts
@@ -227,7 +227,9 @@ export class SchemaFile extends ModuleBuilder<NamespacedZodOptions> {
 
         if (element.members.length === 1) {
           // If there is only one member, just export the schema for that member
-          yield buildMember(element.members[0]);
+          yield `export const ${pascal(name)}Schema = ${buildMember(
+            element.members[0],
+          ).replace(/,$/, ';')};`;
         } else {
           const zodMethod =
             element.kind === 'DiscriminatedUnion'

--- a/packages/zod/src/spec/4.1-structure/4.1.10-property.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.10-property.spec.ts
@@ -1,0 +1,252 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.10 Property', () => {
+  it('emits TypeScript-idiomatic property names for off-brand casing', async () => {
+    // ARRANGE
+    const string = factory.primitiveValue({
+      typeName: factory.primitiveLiteral('string'),
+    });
+
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('snake_case_name'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('kebab-case-name'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('PascalCaseName'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('camelCaseName'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('CONSTANT_CASE_NAME'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('lower case name'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('UPPER CASE NAME'),
+              value: string,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyTypeSchema = z.object({
+        snakeCaseName: z.string(),
+        kebabCaseName: z.string(),
+        pascalCaseName: z.string(),
+        camelCaseName: z.string(),
+        constantCaseName: z.string(),
+        lowerCaseName: z.string(),
+        upperCaseName: z.string(),
+      });
+    `);
+  });
+
+  it('creates a schema for a primitive property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('myString'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({ myString: z.string() });`,
+    );
+  });
+
+  it('creates a schema for a type property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('Type1'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('a'),
+              value: factory.complexValue({
+                typeName: factory.stringLiteral('Type2'),
+              }),
+            }),
+          ],
+        }),
+        factory.type({
+          name: factory.stringLiteral('Type2'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('b'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const Type1Schema = z.object({ a: Type2Schema });
+      export const Type2Schema = z.object({ b: z.string() });
+    `);
+  });
+
+  it('creates a schema for an enum property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('Type1'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('a'),
+              value: factory.complexValue({
+                typeName: factory.stringLiteral('Enum1'),
+              }),
+            }),
+          ],
+        }),
+      ],
+      enums: [
+        factory.enum({
+          name: factory.stringLiteral('Enum1'),
+          members: [
+            factory.enumMember({ content: factory.stringLiteral('MemberA') }),
+            factory.enumMember({ content: factory.stringLiteral('MemberB') }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const Type1Schema = z.object({ a: Enum1Schema });
+      export const Enum1Schema = z.enum(['MemberA', 'MemberB']);
+    `);
+  });
+
+  it('creates a schema for a union property', async () => {
+    // ARRANGE
+
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('Type1'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('a'),
+              value: factory.complexValue({
+                typeName: factory.stringLiteral('Union1'),
+              }),
+            }),
+          ],
+        }),
+      ],
+      unions: [
+        factory.simpleUnion({
+          name: factory.stringLiteral('Union1'),
+          members: [
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('string'),
+            }),
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('number'),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const Type1Schema = z.object({ a: Union1Schema });
+      export const Union1Schema = z.union([ z.string(), z.number() ]);
+    `);
+  });
+
+  it('creates a lazy schema for a circular reference', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('Type1'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('a'),
+              value: factory.complexValue({
+                typeName: factory.stringLiteral('Type2'),
+              }),
+            }),
+          ],
+        }),
+        factory.type({
+          name: factory.stringLiteral('Type2'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('b'),
+              value: factory.complexValue({
+                typeName: factory.stringLiteral('Type1'),
+                isOptional: factory.trueLiteral(),
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const Type1Schema = z.object({ a: z.lazy(() => Type2Schema) });
+      export const Type2Schema = z.object({ b: z.lazy(() => Type1Schema).optional() });
+    `);
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.11-map-properties.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.11-map-properties.spec.ts
@@ -1,0 +1,111 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.11 MapProperties', () => {
+  it('works with basic map properties', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          mapProperties: factory.mapProperties({
+            key: factory.mapKey({
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+            value: factory.mapValue({
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+          }),
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.record(z.string());`,
+    );
+  });
+
+  it('works with required map keys', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          mapProperties: factory.mapProperties({
+            key: factory.mapKey({
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+            requiredKeys: [factory.stringLiteral('propA')],
+            value: factory.mapValue({
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+          }),
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({ propA: z.string() }).catchall(z.string());`,
+    );
+  });
+
+  it('works with mixed properties', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+          ],
+          mapProperties: factory.mapProperties({
+            key: factory.mapKey({
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+            requiredKeys: [factory.stringLiteral('propB')],
+            value: factory.mapValue({
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+              }),
+            }),
+          }),
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyTypeSchema = z.object({
+        propA: z.string(),
+        propB: z.string(),
+      }).catchall(z.string());`);
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.13-primitive-value.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.13-primitive-value.spec.ts
@@ -1,0 +1,364 @@
+import * as IR from '@basketry/ir';
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.13 Primitive Value', () => {
+  describe('typeName', () => {
+    const schemaByPrimitive: [IR.Primitive, string][] = [
+      ['string', 'z.string()'],
+      ['number', 'z.number()'],
+      ['boolean', 'z.boolean()'],
+      ['integer', 'z.number().int()'],
+      ['long', 'z.number().int()'],
+      ['float', 'z.number()'],
+      ['double', 'z.number()'],
+      ['date', 'z.coerce.date()'],
+      ['date-time', 'z.coerce.date()'],
+      ['null', 'z.literal(null)'],
+      ['binary', 'z.any()'],
+      ['untyped', 'z.any()'],
+    ];
+
+    it.each(schemaByPrimitive)(
+      'creates a schema for a %s primitive value',
+      async (primitive, expected) => {
+        // ARRANGE
+        const service = factory.service({
+          types: [
+            factory.type({
+              name: factory.stringLiteral('MyType'),
+              properties: [
+                factory.property({
+                  name: factory.stringLiteral('propA'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral(primitive),
+                  }),
+                }),
+              ],
+            }),
+          ],
+        });
+
+        // ACT
+        const result = await schemaGenerator(service);
+
+        // ASSERT
+        expect(result[0].contents).toContainAst(
+          `export const MyTypeSchema = z.object({ propA: ${expected} });`,
+        );
+      },
+    );
+  });
+
+  describe('isArray', () => {
+    const schemaByPrimitive: [IR.Primitive, string][] = [
+      ['string', 'z.string().array()'],
+      ['number', 'z.number().array()'],
+      ['boolean', 'z.boolean().array()'],
+      ['integer', 'z.number().int().array()'],
+      ['long', 'z.number().int().array()'],
+      ['float', 'z.number().array()'],
+      ['double', 'z.number().array()'],
+      ['date', 'z.coerce.date().array()'],
+      ['date-time', 'z.coerce.date().array()'],
+      ['null', 'z.literal(null).array()'],
+      ['binary', 'z.any().array()'],
+      ['untyped', 'z.any().array()'],
+    ];
+
+    it.each(schemaByPrimitive)(
+      'creates a schema for a %s primitive array',
+      async (primitive, expected) => {
+        // ARRANGE
+        const service = factory.service({
+          types: [
+            factory.type({
+              name: factory.stringLiteral('MyType'),
+              properties: [
+                factory.property({
+                  name: factory.stringLiteral('propA'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral(primitive),
+                    isArray: factory.trueLiteral(),
+                  }),
+                }),
+              ],
+            }),
+          ],
+        });
+
+        // ACT
+        const result = await schemaGenerator(service);
+
+        // ASSERT
+        expect(result[0].contents).toContainAst(
+          `export const MyTypeSchema = z.object({ propA: ${expected} });`,
+        );
+      },
+    );
+  });
+
+  describe('isNullable', () => {
+    const schemaByPrimitive: [IR.Primitive, string][] = [
+      ['string', 'z.string().nullable()'],
+      ['number', 'z.number().nullable()'],
+      ['boolean', 'z.boolean().nullable()'],
+      ['integer', 'z.number().int().nullable()'],
+      ['long', 'z.number().int().nullable()'],
+      ['float', 'z.number().nullable()'],
+      ['double', 'z.number().nullable()'],
+      ['date', 'z.coerce.date().nullable()'],
+      ['date-time', 'z.coerce.date().nullable()'],
+      ['null', 'z.literal(null).nullable()'],
+      ['binary', 'z.any().nullable()'],
+      ['untyped', 'z.any().nullable()'],
+    ];
+
+    it.each(schemaByPrimitive)(
+      'creates a schema for a nullable %s primitive value',
+      async (primitive, expected) => {
+        // ARRANGE
+        const service = factory.service({
+          types: [
+            factory.type({
+              name: factory.stringLiteral('MyType'),
+              properties: [
+                factory.property({
+                  name: factory.stringLiteral('propA'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral(primitive),
+                    isNullable: factory.trueLiteral(),
+                  }),
+                }),
+              ],
+            }),
+          ],
+        });
+
+        // ACT
+        const result = await schemaGenerator(service);
+
+        // ASSERT
+        expect(result[0].contents).toContainAst(
+          `export const MyTypeSchema = z.object({ propA: ${expected} });`,
+        );
+      },
+    );
+  });
+
+  describe('isOptional', () => {
+    const schemaByPrimitive: [IR.Primitive, string][] = [
+      ['string', 'z.string().optional()'],
+      ['number', 'z.number().optional()'],
+      ['boolean', 'z.boolean().optional()'],
+      ['integer', 'z.number().int().optional()'],
+      ['long', 'z.number().int().optional()'],
+      ['float', 'z.number().optional()'],
+      ['double', 'z.number().optional()'],
+      ['date', 'z.coerce.date().optional()'],
+      ['date-time', 'z.coerce.date().optional()'],
+      ['null', 'z.literal(null).optional()'],
+      ['binary', 'z.any().optional()'],
+      ['untyped', 'z.any().optional()'],
+    ];
+
+    it.each(schemaByPrimitive)(
+      'creates a schema for an optional %s primitive value',
+      async (primitive, expected) => {
+        // ARRANGE
+        const service = factory.service({
+          types: [
+            factory.type({
+              name: factory.stringLiteral('MyType'),
+              properties: [
+                factory.property({
+                  name: factory.stringLiteral('propA'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral(primitive),
+                    isOptional: factory.trueLiteral(),
+                  }),
+                }),
+              ],
+            }),
+          ],
+        });
+
+        // ACT
+        const result = await schemaGenerator(service);
+
+        // ASSERT
+        expect(result[0].contents).toContainAst(
+          `export const MyTypeSchema = z.object({ propA: ${expected} });`,
+        );
+      },
+    );
+  });
+
+  describe('constant', () => {
+    const constantAndSchemaByPrimitive: [
+      IR.Primitive,
+      IR.PrimitiveValueDefault,
+      string,
+    ][] = [
+      ['string', factory.stringLiteral('my str'), 'z.literal("my str")'],
+      ['number', factory.numberLiteral(123.45), 'z.literal(123.45)'],
+      ['boolean', factory.booleanLiteral(true), 'z.literal(true)'],
+      ['integer', factory.numberLiteral(67), 'z.literal(67)'],
+      [
+        'long',
+        factory.numberLiteral(38467534867534),
+        'z.literal(38467534867534)',
+      ],
+      [
+        'float',
+        factory.numberLiteral(8742254.23434),
+        'z.literal(8742254.23434)',
+      ],
+      ['double', factory.numberLiteral(123.456789), 'z.literal(123.456789)'],
+      ['null', factory.nullLiteral(), 'z.literal(null)'],
+    ];
+
+    it.each(constantAndSchemaByPrimitive)(
+      'creates a schema for a %s primitive with a constant value',
+      async (primitive, constant, expected) => {
+        // ARRANGE
+        const service = factory.service({
+          types: [
+            factory.type({
+              name: factory.stringLiteral('MyType'),
+              properties: [
+                factory.property({
+                  name: factory.stringLiteral('propA'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral(primitive),
+                    constant,
+                  }),
+                }),
+              ],
+            }),
+          ],
+        });
+
+        // ACT
+        const result = await schemaGenerator(service);
+
+        // ASSERT
+        expect(result[0].contents).toContainAst(
+          `export const MyTypeSchema = z.object({ propA: ${expected} });`,
+        );
+      },
+    );
+  });
+
+  describe('default', () => {
+    const defaultAndSchemaByPrimitive: [
+      IR.Primitive,
+      IR.PrimitiveValueDefault,
+      string,
+    ][] = [
+      [
+        'string',
+        factory.stringLiteral('my str'),
+        'z.string().default("my str")',
+      ],
+      ['number', factory.numberLiteral(123.45), 'z.number().default(123.45)'],
+      ['boolean', factory.booleanLiteral(true), 'z.boolean().default(true)'],
+      ['integer', factory.numberLiteral(67), 'z.number().int().default(67)'],
+      [
+        'long',
+        factory.numberLiteral(38467534867534),
+        'z.number().int().default(38467534867534)',
+      ],
+      [
+        'float',
+        factory.numberLiteral(8742254.23434),
+        'z.number().default(8742254.23434)',
+      ],
+      [
+        'double',
+        factory.numberLiteral(123.456789),
+        'z.number().default(123.456789)',
+      ],
+      ['null', factory.nullLiteral(), 'z.literal(null)'],
+    ];
+
+    it.each(defaultAndSchemaByPrimitive)(
+      'creates a schema for a %s primitive with a default value',
+      async (primitive, value, expected) => {
+        // ARRANGE
+        const service = factory.service({
+          types: [
+            factory.type({
+              name: factory.stringLiteral('MyType'),
+              properties: [
+                factory.property({
+                  name: factory.stringLiteral('propA'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral(primitive),
+                    default: value,
+                  }),
+                }),
+              ],
+            }),
+          ],
+        });
+
+        // ACT
+        const result = await schemaGenerator(service);
+
+        // ASSERT
+        expect(result[0].contents).toContainAst(
+          `export const MyTypeSchema = z.object({ propA: ${expected} });`,
+        );
+      },
+    );
+  });
+
+  describe('misc', () => {
+    it('build schema with correct order of operations', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('integer'),
+                  isArray: factory.trueLiteral(),
+                  isOptional: factory.trueLiteral(),
+                  isNullable: factory.trueLiteral(),
+                  rules: [
+                    factory.numberGteRule(43),
+                    factory.numberLtRule(100),
+                    factory.arrayMaxItemsRule(10),
+                  ],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(`
+        export const MyTypeSchema = z.object({ propA:
+        z.number()
+          .int()
+          .gte(43)
+          .lt(100)
+          .array()
+          .max(10)
+          .nullable()
+          .optional()
+        });
+      `);
+    });
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.15-parameter.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.15-parameter.spec.ts
@@ -1,0 +1,82 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+import * as IR from '@basketry/ir';
+
+// type Primitive = "string" | "number" | "boolean" | "integer" | "long" | "float" | "double" | "date" | "date-time" | "null" | "binary" | "untyped"
+
+const factory = new Factory();
+
+describe('4.1.15 Parameter', () => {
+  const coercedLocations: IR.HttpLocation[] = ['query', 'path', 'header'];
+  const testCases: [IR.Primitive, string][] = [
+    ['string', 'z.string()'],
+    ['number', 'z.coerce.number()'],
+    ['boolean', 'booleanFromString'],
+    ['integer', 'z.coerce.number().int()'],
+    ['long', 'z.coerce.number().int()'],
+    ['float', 'z.coerce.number()'],
+    ['double', 'z.coerce.number()'],
+    ['date', 'z.coerce.date()'],
+    ['date-time', 'z.coerce.date()'],
+    ['null', 'z.literal(null)'],
+  ];
+
+  describe.each(coercedLocations)(
+    'properly coerces parameters in %s',
+    (location) => {
+      it.each(testCases)(
+        'properly coerces %s to %s',
+        async (primitive, expected) => {
+          // ARRANGE
+          const methodName = factory.stringLiteral('myMethod');
+          const paramName = factory.stringLiteral('myParam');
+
+          const service = factory.service({
+            interfaces: [
+              factory.interface({
+                protocols: factory.protocols({
+                  http: [
+                    factory.httpRoute({
+                      methods: [
+                        factory.httpMethod({
+                          name: methodName,
+                          parameters: [
+                            factory.httpParameter({
+                              name: paramName,
+                              location: factory.httpLocationLiteral(location),
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+                methods: [
+                  factory.method({
+                    name: methodName,
+                    parameters: [
+                      factory.parameter({
+                        name: paramName,
+                        value: factory.primitiveValue({
+                          typeName: factory.primitiveLiteral(primitive),
+                        }),
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          });
+
+          // ACT
+          const result = await schemaGenerator(service);
+
+          // ASSERT
+          expect(result[0].contents).toContainAst(
+            `export const MyMethodParamsSchema = z.object({ myParam: ${expected} });`,
+          );
+        },
+      );
+    },
+  );
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.3-type.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.3-type.spec.ts
@@ -1,0 +1,145 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.3 Type', () => {
+  it('creates a schema for a type without properties', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [factory.type({ name: factory.stringLiteral('MyType') })],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyTypeSchema = z.record(z.any());
+    `);
+  });
+
+  it('creates a schema for a type with properties', async () => {
+    // ARRANGE
+    const string = factory.primitiveValue({
+      typeName: factory.primitiveLiteral('string'),
+    });
+    const integer = factory.primitiveValue({
+      typeName: factory.primitiveLiteral('integer'),
+    });
+
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('propB'),
+              value: integer,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyTypeSchema = z.object({
+        propA: z.string(),
+        propB: z.number().int(),
+      });
+    `);
+  });
+
+  it('creates a schema for a type with map properties', async () => {
+    // ARRANGE
+    const string = factory.primitiveValue({
+      typeName: factory.primitiveLiteral('string'),
+    });
+
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          mapProperties: factory.mapProperties({
+            key: factory.mapKey({ value: string }),
+            value: factory.mapValue({ value: string }),
+          }),
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.record(z.string());`,
+    );
+  });
+
+  it('creates a schema for a type with properties and map properties', async () => {
+    // ARRANGE
+    const string = factory.primitiveValue({
+      typeName: factory.primitiveLiteral('string'),
+    });
+    const integer = factory.primitiveValue({
+      typeName: factory.primitiveLiteral('integer'),
+    });
+
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: string,
+            }),
+            factory.property({
+              name: factory.stringLiteral('propB'),
+              value: integer,
+            }),
+          ],
+          mapProperties: factory.mapProperties({
+            key: factory.mapKey({ value: string }),
+            value: factory.mapValue({ value: string }),
+          }),
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyTypeSchema = z.object({
+        propA: z.string(),
+        propB: z.number().int(),
+      }).catchall(z.string());
+    `);
+  });
+
+  it('emits a TypeScript-idiomatic name when the type name is not in PascalCase', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [factory.type({ name: factory.stringLiteral('my type') })],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyTypeSchema = z.record(z.any());
+    `);
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.4-enum.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.4-enum.spec.ts
@@ -1,0 +1,54 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.4 Enum', () => {
+  it('creates a schema for an enum', async () => {
+    // ARRANGE
+    const service = factory.service({
+      enums: [
+        factory.enum({
+          name: factory.stringLiteral('MyEnum'),
+          members: [
+            factory.enumMember({ content: factory.stringLiteral('FOO') }),
+            factory.enumMember({ content: factory.stringLiteral('BAR') }),
+            factory.enumMember({ content: factory.stringLiteral('BAZ') }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+        export const MyEnumSchema = z.enum(['FOO', 'BAR', 'BAZ']);
+      `);
+  });
+
+  it('emits a TypeScript-idiomatic name when the enum name is not in PascalCase', async () => {
+    // ARRANGE
+    const service = factory.service({
+      enums: [
+        factory.enum({
+          name: factory.stringLiteral('my enum'),
+          members: [
+            factory.enumMember({ content: factory.stringLiteral('FOO') }),
+            factory.enumMember({ content: factory.stringLiteral('BAR') }),
+            factory.enumMember({ content: factory.stringLiteral('BAZ') }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+        export const MyEnumSchema = z.enum(['FOO', 'BAR', 'BAZ']);
+      `);
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.5-simple-union.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.5-simple-union.spec.ts
@@ -1,0 +1,160 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.5 Simple Union', () => {
+  it('allows for complex types to be members of a union', async () => {
+    // ARRANGE
+    const typeA = factory.type({ name: factory.stringLiteral('TypeA') });
+    const typeB = factory.type({ name: factory.stringLiteral('TypeB') });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.simpleUnion({
+          name: factory.stringLiteral('MyUnion'),
+          members: [
+            factory.complexValue({ typeName: typeA.name }),
+            factory.complexValue({ typeName: typeB.name }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyUnionSchema = z.union([TypeASchema, TypeBSchema]);`,
+    );
+  });
+
+  it('allows for primitive types to be members of a union', async () => {
+    // ARRANGE
+    const service = factory.service({
+      unions: [
+        factory.simpleUnion({
+          name: factory.stringLiteral('MyUnion'),
+          members: [
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('string'),
+            }),
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('number'),
+            }),
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('boolean'),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyUnionSchema = z.union([
+        z.string(),
+        z.number(),
+        z.boolean(),
+      ]);
+    `);
+  });
+
+  it('allows for mixed types to be members of a union', async () => {
+    // ARRANGE
+    const typeA = factory.type({ name: factory.stringLiteral('TypeA') });
+    const typeB = factory.type({ name: factory.stringLiteral('TypeB') });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.simpleUnion({
+          name: factory.stringLiteral('MyUnion'),
+          members: [
+            factory.complexValue({ typeName: typeA.name }),
+            factory.complexValue({ typeName: typeB.name }),
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('string'),
+            }),
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('number'),
+            }),
+            factory.primitiveValue({
+              typeName: factory.primitiveLiteral('boolean'),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyUnionSchema = z.union([
+        TypeASchema,
+        TypeBSchema,
+        z.string(),
+        z.number(),
+        z.boolean(),
+      ]);
+    `);
+  });
+
+  it('creates an "alias" when a union only has one member', async () => {
+    // ARRANGE
+    const typeA = factory.type({ name: factory.stringLiteral('TypeA') });
+    const typeB = factory.type({ name: factory.stringLiteral('TypeB') });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.simpleUnion({
+          name: factory.stringLiteral('MyUnion'),
+          members: [factory.complexValue({ typeName: typeA.name })],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyUnionSchema = TypeASchema;
+    `);
+  });
+
+  it('emits a TypeScript-idiomatic name when the union name is not in PascalCase', async () => {
+    // ARRANGE
+    const typeA = factory.type({ name: factory.stringLiteral('TypeA') });
+    const typeB = factory.type({ name: factory.stringLiteral('TypeB') });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.simpleUnion({
+          name: factory.stringLiteral('my union'),
+          members: [
+            factory.complexValue({ typeName: typeA.name }),
+            factory.complexValue({ typeName: typeB.name }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyUnionSchema = z.union([TypeASchema, TypeBSchema]);`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.6-discriminated-union.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.6-discriminated-union.spec.ts
@@ -1,0 +1,156 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.5 Simple Union', () => {
+  it('creates a schema for a discriminated union type', async () => {
+    // ARRANGE
+    const key = factory.property({
+      name: factory.stringLiteral('type'),
+      value: factory.primitiveValue({
+        typeName: factory.primitiveLiteral('string'),
+      }),
+    });
+
+    const typeA = factory.type({
+      name: factory.stringLiteral('TypeA'),
+      properties: [
+        key,
+        factory.property({ name: factory.stringLiteral('a') }),
+        factory.property({ name: factory.stringLiteral('b') }),
+      ],
+    });
+    const typeB = factory.type({
+      name: factory.stringLiteral('TypeB'),
+      properties: [
+        key,
+        factory.property({ name: factory.stringLiteral('c') }),
+        factory.property({ name: factory.stringLiteral('d') }),
+      ],
+    });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.discriminatedUnion({
+          name: factory.stringLiteral('MyUnion'),
+          discriminator: key.name,
+          members: [
+            factory.complexValue({ typeName: typeA.name }),
+            factory.complexValue({ typeName: typeB.name }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyUnionSchema = z.discriminatedUnion('type', [
+        TypeASchema,
+        TypeBSchema
+      ]);
+    `);
+  });
+
+  it('creates an "alias" when a union only has one member', async () => {
+    // ARRANGE
+    const key = factory.property({
+      name: factory.stringLiteral('type'),
+      value: factory.primitiveValue({
+        typeName: factory.primitiveLiteral('string'),
+      }),
+    });
+
+    const typeA = factory.type({
+      name: factory.stringLiteral('TypeA'),
+      properties: [
+        key,
+        factory.property({ name: factory.stringLiteral('a') }),
+        factory.property({ name: factory.stringLiteral('b') }),
+      ],
+    });
+    const typeB = factory.type({
+      name: factory.stringLiteral('TypeB'),
+      properties: [
+        key,
+        factory.property({ name: factory.stringLiteral('c') }),
+        factory.property({ name: factory.stringLiteral('d') }),
+      ],
+    });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.discriminatedUnion({
+          name: factory.stringLiteral('MyUnion'),
+          discriminator: key.name,
+          members: [factory.complexValue({ typeName: typeA.name })],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyUnionSchema = TypeASchema;`,
+    );
+  });
+
+  it('emits a TypeScript-idiomatic name when the union name is not in PascalCase', async () => {
+    // ARRANGE
+    const key = factory.property({
+      name: factory.stringLiteral('type'),
+      value: factory.primitiveValue({
+        typeName: factory.primitiveLiteral('string'),
+      }),
+    });
+
+    const typeA = factory.type({
+      name: factory.stringLiteral('TypeA'),
+      properties: [
+        key,
+        factory.property({ name: factory.stringLiteral('a') }),
+        factory.property({ name: factory.stringLiteral('b') }),
+      ],
+    });
+    const typeB = factory.type({
+      name: factory.stringLiteral('TypeB'),
+      properties: [
+        key,
+        factory.property({ name: factory.stringLiteral('c') }),
+        factory.property({ name: factory.stringLiteral('d') }),
+      ],
+    });
+
+    const service = factory.service({
+      types: [typeA, typeB],
+      unions: [
+        factory.discriminatedUnion({
+          name: factory.stringLiteral('my union'),
+          discriminator: key.name,
+          members: [
+            factory.complexValue({ typeName: typeA.name }),
+            factory.complexValue({ typeName: typeB.name }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyUnionSchema = z.discriminatedUnion('type', [
+        TypeASchema,
+        TypeBSchema
+      ]);
+    `);
+  });
+});

--- a/packages/zod/src/spec/4.1-structure/4.1.8-method.spec.ts
+++ b/packages/zod/src/spec/4.1-structure/4.1.8-method.spec.ts
@@ -1,0 +1,65 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.1.8 Method', () => {
+  it('does not emit a params type for a method with no parameters', async () => {
+    // ARRANGE
+    const service = factory.service({
+      interfaces: [
+        factory.interface({
+          methods: [
+            factory.method({ name: factory.stringLiteral('myMethod') }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).not.toContain('MyMethodParamsSchema');
+  });
+
+  it('emits a params type for a method with parameters', async () => {
+    // ARRANGE
+    const service = factory.service({
+      interfaces: [
+        factory.interface({
+          methods: [
+            factory.method({
+              name: factory.stringLiteral('myMethod'),
+              parameters: [
+                factory.parameter({
+                  name: factory.stringLiteral('param1'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral('string'),
+                  }),
+                }),
+                factory.parameter({
+                  name: factory.stringLiteral('param2'),
+                  value: factory.primitiveValue({
+                    typeName: factory.primitiveLiteral('integer'),
+                  }),
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(`
+      export const MyMethodParamsSchema = z.object({
+        param1: z.string(),
+        param2: z.number().int(),
+      });
+    `);
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.1-string-max-length-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.1-string-max-length-rule.spec.ts
@@ -1,0 +1,63 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.1 StringMaxLengthRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                rules: [factory.stringMaxLengthRule(5)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().max(5)});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.stringMaxLengthRule(5)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().max(5).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.10-array-max-items-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.10-array-max-items-rule.spec.ts
@@ -1,0 +1,65 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.10 ArrayMaxItemsRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isArray: factory.trueLiteral(),
+                rules: [factory.arrayMaxItemsRule(67)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().array().max(67)});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isOptional: factory.trueLiteral(),
+                isArray: factory.trueLiteral(),
+                rules: [factory.arrayMaxItemsRule(67)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().array().max(67).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.11-array-min-items-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.11-array-min-items-rule.spec.ts
@@ -1,0 +1,94 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.11 ArrayMinItemsRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isArray: factory.trueLiteral(),
+                rules: [factory.arrayMinItemsRule(5)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().array().min(5)});`,
+    );
+  });
+
+  it('applies the `nonempty` rule if a value of 1 is specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isArray: factory.trueLiteral(),
+                rules: [factory.arrayMinItemsRule(1)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().array().nonempty()});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isOptional: factory.trueLiteral(),
+                isArray: factory.trueLiteral(),
+                rules: [factory.arrayMinItemsRule(5)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().array().min(5).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.2-string-min-length-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.2-string-min-length-rule.spec.ts
@@ -1,0 +1,63 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.2 StringMinLengthRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                rules: [factory.stringMinLengthRule(5)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().min(5)});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.stringMinLengthRule(5)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().min(5).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.3-string-pattern-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.3-string-pattern-rule.spec.ts
@@ -1,0 +1,63 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.3 StringPatternRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                rules: [factory.stringPatternRule('^[a-z]+$')],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().regex(/^[a-z]+$/)});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.stringPatternRule('^[a-z]+$')],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().regex(/^[a-z]+$/).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.4-string-format-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.4-string-format-rule.spec.ts
@@ -1,0 +1,655 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.4 StringFormatRule', () => {
+  describe('email', () => {
+    it('applies the email validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('email')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().email()});`,
+      );
+    });
+
+    it('applies the email validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('email')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().email().optional()});`,
+      );
+    });
+  });
+
+  describe('url', () => {
+    it('applies the url validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('url')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().url()});`,
+      );
+    });
+
+    it('applies the url validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('url')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().url().optional()});`,
+      );
+    });
+  });
+
+  describe('emoji', () => {
+    it('applies the emoji validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('emoji')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().emoji()});`,
+      );
+    });
+
+    it('applies the emoji validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('emoji')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().emoji().optional()});`,
+      );
+    });
+  });
+
+  describe('uuid', () => {
+    it('applies the uuid validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('uuid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().uuid()});`,
+      );
+    });
+
+    it('applies the uuid validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('uuid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().uuid().optional()});`,
+      );
+    });
+  });
+
+  describe('nanoid', () => {
+    it('applies the nanoid validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('nanoid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().nanoid()});`,
+      );
+    });
+
+    it('applies the nanoid validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('nanoid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().nanoid().optional()});`,
+      );
+    });
+  });
+
+  describe('cuid', () => {
+    it('applies the cuid validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('cuid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().cuid()});`,
+      );
+    });
+
+    it('applies the cuid validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('cuid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().cuid().optional()});`,
+      );
+    });
+  });
+
+  describe('cuid2', () => {
+    it('applies the cuid2 validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('cuid2')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().cuid2()});`,
+      );
+    });
+
+    it('applies the cuid2 validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('cuid2')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().cuid2().optional()});`,
+      );
+    });
+  });
+
+  describe('ulid', () => {
+    it('applies the ulid validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('ulid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().ulid()});`,
+      );
+    });
+
+    it('applies the ulid validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('ulid')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().ulid().optional()});`,
+      );
+    });
+  });
+
+  describe('ip', () => {
+    it('applies the ip validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('ip')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().ip()});`,
+      );
+    });
+
+    it('applies the ip validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('ip')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().ip().optional()});`,
+      );
+    });
+  });
+
+  describe('cidr', () => {
+    it('applies the cidr validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('cidr')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().cidr()});`,
+      );
+    });
+
+    it('applies the cidr validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('cidr')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().cidr().optional()});`,
+      );
+    });
+  });
+
+  describe('base64', () => {
+    it('applies the base64 validator to a required property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  rules: [factory.stringFormatRule('base64')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().base64()});`,
+      );
+    });
+
+    it('applies the base64 validator to an optional property', async () => {
+      // ARRANGE
+      const service = factory.service({
+        types: [
+          factory.type({
+            name: factory.stringLiteral('MyType'),
+            properties: [
+              factory.property({
+                name: factory.stringLiteral('propA'),
+                value: factory.primitiveValue({
+                  typeName: factory.primitiveLiteral('string'),
+                  isOptional: factory.trueLiteral(),
+                  rules: [factory.stringFormatRule('base64')],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // ACT
+      const result = await schemaGenerator(service);
+
+      // ASSERT
+      expect(result[0].contents).toContainAst(
+        `export const MyTypeSchema = z.object({propA: z.string().base64().optional()});`,
+      );
+    });
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.5-number-multiple-of-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.5-number-multiple-of-rule.spec.ts
@@ -1,0 +1,63 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.5 NumberMultipleOfRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberMultipleOfRule(13)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().multipleOf(13)});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.numberMultipleOfRule(13)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().multipleOf(13).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.6-number-gt-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.6-number-gt-rule.spec.ts
@@ -1,0 +1,91 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.6 NumberGtRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberGtRule(67)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().gt(67)});`,
+    );
+  });
+
+  it('applies the `positive` rule if a "greater than" value of 0 is specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberGtRule(0)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().positive()});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.numberGtRule(67)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().gt(67).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.7-number-gte-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.7-number-gte-rule.spec.ts
@@ -1,0 +1,91 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.7 NumberGteRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberGteRule(42)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().gte(42)});`,
+    );
+  });
+
+  it('applies the `nonnegative` rule if a "greater than or equal" value of 0 is specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberGteRule(0)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().nonnegative()});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.numberGteRule(42)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().gte(42).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.8-number-lt-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.8-number-lt-rule.spec.ts
@@ -1,0 +1,91 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.8 NumberLtRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberLtRule(1337)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().lt(1337)});`,
+    );
+  });
+
+  it('applies the `negative` rule if a "less than" value of 0 is specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberLtRule(0)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().negative()});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.numberLtRule(1337)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().lt(1337).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/4.2.9-number-lte-rule.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/4.2.9-number-lte-rule.spec.ts
@@ -1,0 +1,91 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('4.2.9 NumberLteRule', () => {
+  it('applies the rule to a required property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberLteRule(22)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().lte(22)});`,
+    );
+  });
+
+  it('applies the `nonpositive` rule if a "less than or equal" value of 0 is specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                rules: [factory.numberLteRule(0)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().nonpositive()});`,
+    );
+  });
+
+  it('applies the rule to an optional property', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('number'),
+                isOptional: factory.trueLiteral(),
+                rules: [factory.numberLteRule(22)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.number().lte(22).optional()});`,
+    );
+  });
+});

--- a/packages/zod/src/spec/4.2-rules/string-rule-optimizations.spec.ts
+++ b/packages/zod/src/spec/4.2-rules/string-rule-optimizations.spec.ts
@@ -1,0 +1,65 @@
+import { Factory } from '@basketry/jest-utils';
+import schemaGenerator from '../..';
+
+const factory = new Factory();
+
+describe('String rule optimizations', () => {
+  it('applies the `length` rule if an equal min and max length are specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                rules: [
+                  factory.stringMinLengthRule(5),
+                  factory.stringMaxLengthRule(5),
+                ],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().length(5)});`,
+    );
+  });
+
+  it('applies the `nonempty` rule if a min length of 1 is specified', async () => {
+    // ARRANGE
+    const service = factory.service({
+      types: [
+        factory.type({
+          name: factory.stringLiteral('MyType'),
+          properties: [
+            factory.property({
+              name: factory.stringLiteral('propA'),
+              value: factory.primitiveValue({
+                typeName: factory.primitiveLiteral('string'),
+                rules: [factory.stringMinLengthRule(1)],
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    // ACT
+    const result = await schemaGenerator(service);
+
+    // ASSERT
+    expect(result[0].contents).toContainAst(
+      `export const MyTypeSchema = z.object({propA: z.string().nonempty()});`,
+    );
+  });
+});

--- a/utils/jest-utils/LICENSE
+++ b/utils/jest-utils/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2025 Steve Konves <stephen.konves@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/utils/jest-utils/package.json
+++ b/utils/jest-utils/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@basketry/jest-utils",
+  "version": "0.0.0",
+  "description": "Utilities for writing AST-based tests with Jest",
+  "main": "src/index.js",
+  "scripts": {
+    "prebuild": "run-s -s clean",
+    "build": "tsc",
+    "clean": "run-s -s clean:*",
+    "clean:coverage": "rimraf coverage",
+    "clean:output": "rimraf lib",
+    "prepack": "run-s -s build"
+  },
+  "keywords": [],
+  "author": "Steve Konves",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/basketry/typescript.git",
+    "directory": "packages/typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/basketry/typescript/issues"
+  }
+}

--- a/utils/jest-utils/src/factory.ts
+++ b/utils/jest-utils/src/factory.ts
@@ -1,0 +1,550 @@
+import * as IR from '@basketry/ir';
+
+type Override<T, K extends keyof T | undefined = undefined> = K extends keyof T
+  ? Partial<Omit<T, 'kind' | K>>
+  : Partial<Omit<T, 'kind'>>;
+
+export class Factory {
+  constructor(private readonly seed?: number) {
+    if (this.seed !== undefined) {
+      // Simple seeded random number generator using a linear congruential generator
+      const a = 1664525;
+      const c = 1013904223;
+      const m = 0x100000000; // 2^32
+      this._random = (a * this.seed + c) % m;
+    } else {
+      // Generate a random number between 0 and 16^8-1
+      this._random = Math.floor(Math.random() * 0x100000000);
+    }
+  }
+
+  private _random: number;
+
+  private rnd(name: string): string {
+    // Convert to hex string and pad with zeros if necessary
+    return `${name}${this._random.toString(16).padStart(8, '0')}`;
+  }
+
+  // 4.1 Structure
+
+  // 4.1.1 Service
+  service(obj?: Override<IR.Service, 'basketry'>): IR.Service {
+    const {
+      title,
+      sourcePaths,
+      majorVersion,
+      interfaces,
+      types,
+      enums,
+      unions,
+      ...rest
+    } = obj || {};
+
+    return {
+      kind: 'Service',
+      basketry: '0.2',
+      title: title ?? this.stringLiteral(this.rnd('Service')),
+      sourcePaths: sourcePaths ?? ['#'],
+      majorVersion: majorVersion ?? this.integerLiteral(1),
+      interfaces: interfaces ?? [],
+      types: types ?? [],
+      enums: enums ?? [],
+      unions: unions ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.2 Interface
+  interface(obj?: Override<IR.Interface>): IR.Interface {
+    const { name, description, methods, ...rest } = obj || {};
+
+    return {
+      kind: 'Interface',
+      name: name ?? this.stringLiteral(this.rnd('Interface')),
+      description: description ?? [],
+      methods: methods ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.3 Type
+  type(obj?: Override<IR.Type>): IR.Type {
+    const {
+      name,
+      description,
+      deprecated,
+      properties,
+      mapProperties,
+      rules,
+      ...rest
+    } = obj || {};
+    return {
+      kind: 'Type',
+      name: name ?? this.stringLiteral(this.rnd('Type')),
+      description,
+      deprecated,
+      properties: properties ?? [],
+      mapProperties,
+      rules: [],
+      ...rest,
+    };
+  }
+
+  // 4.1.4 Enum
+  enum(obj?: Override<IR.Enum>): IR.Enum {
+    const { name, description, members, ...rest } = obj || {};
+
+    return {
+      kind: 'Enum',
+      name: name ?? this.stringLiteral(this.rnd('Enum')),
+      description,
+      members: members ?? [this.enumMember()],
+      ...rest,
+    };
+  }
+
+  // 4.1.5 SimpleUnion
+  simpleUnion(obj?: Override<IR.SimpleUnion>): IR.SimpleUnion {
+    const { name, description, members, ...rest } = obj || {};
+
+    return {
+      kind: 'SimpleUnion',
+      name: name ?? this.stringLiteral(this.rnd('SimpleUnion')),
+      description,
+      members: members ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.6 Discriminated Union
+  discriminatedUnion(
+    obj?: Override<IR.DiscriminatedUnion>,
+  ): IR.DiscriminatedUnion {
+    const { name, description, discriminator, members, ...rest } = obj || {};
+
+    return {
+      kind: 'DiscriminatedUnion',
+      name: name ?? this.stringLiteral(this.rnd('DiscriminatedUnion')),
+      description,
+      discriminator: discriminator ?? this.stringLiteral('type'),
+      members: members ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.8 Method
+  method(obj?: Override<IR.Method>): IR.Method {
+    const {
+      name,
+      description,
+      deprecated,
+      parameters,
+      security,
+      returns,
+      ...rest
+    } = obj || {};
+
+    return {
+      kind: 'Method',
+      name: name ?? this.stringLiteral(this.rnd('method')),
+      description,
+      deprecated,
+      parameters: parameters ?? [],
+      security: security ?? [],
+      returns,
+      ...rest,
+    };
+  }
+
+  // 4.1.9 Protocols
+  protocols(obj?: Override<IR.Protocols>): IR.Protocols {
+    const { http, ...rest } = obj || {};
+
+    return {
+      kind: 'InterfaceProtocols',
+      http,
+      ...rest,
+    };
+  }
+
+  // 4.1.10 Property
+  property(obj?: Override<IR.Property>): IR.Property {
+    const { name, value, description, deprecated, ...rest } = obj || {};
+
+    return {
+      kind: 'Property',
+      name: name ?? this.stringLiteral(this.rnd('property')),
+      description,
+      deprecated,
+      value:
+        value ??
+        this.primitiveValue({ typeName: this.primitiveLiteral('string') }),
+      ...rest,
+    };
+  }
+
+  // 4.1.11 MapProperties
+  mapProperties(obj?: Override<IR.MapProperties>): IR.MapProperties {
+    const { key, requiredKeys, value, ...rest } = obj || {};
+
+    return {
+      kind: 'MapProperties',
+      key: key ?? this.mapKey(),
+      requiredKeys: requiredKeys ?? [],
+      value: value ?? this.mapValue(),
+      ...rest,
+    };
+  }
+
+  // 4.1.12 EnumMember
+  enumMember(obj?: Override<IR.EnumMember>): IR.EnumMember {
+    const { content, ...rest } = obj || {};
+
+    return {
+      kind: 'EnumMember',
+      content: content ?? this.stringLiteral(this.rnd('EnumMember')),
+      ...rest,
+    };
+  }
+
+  // 4.1.13 PrimitiveValue
+  primitiveValue(obj?: Override<IR.PrimitiveValue>): IR.PrimitiveValue {
+    const { typeName, rules, ...rest } = obj || {};
+
+    return {
+      kind: 'PrimitiveValue',
+      typeName: typeName ?? this.primitiveLiteral('string'),
+      rules: rules ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.14 ComplexValue
+  complexValue(obj?: Override<IR.ComplexValue>): IR.ComplexValue {
+    const { typeName, rules, ...rest } = obj || {};
+
+    return {
+      kind: 'ComplexValue',
+      typeName: typeName ?? this.stringLiteral(this.rnd('Type')),
+      rules: rules ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.15 Parameter
+  parameter(obj?: Override<IR.Parameter>): IR.Parameter {
+    const { name, value, description, deprecated, ...rest } = obj || {};
+
+    return {
+      kind: 'Parameter',
+      name: name ?? this.stringLiteral(this.rnd('parameter')),
+      description,
+      deprecated,
+      value:
+        value ??
+        this.primitiveValue({ typeName: this.primitiveLiteral('string') }),
+      ...rest,
+    };
+  }
+
+  // 4.1.17 ReturnValue
+  returnValue(obj?: Override<IR.ReturnValue>): IR.ReturnValue {
+    const { value, ...rest } = obj || {};
+
+    return {
+      kind: 'ReturnValue',
+      value:
+        value ??
+        this.primitiveValue({ typeName: this.primitiveLiteral('string') }),
+      ...rest,
+    };
+  }
+
+  // 4.1.18 HttpRoute
+  httpRoute(obj?: Override<IR.HttpRoute>): IR.HttpRoute {
+    const { pattern, methods, ...rest } = obj || {};
+
+    return {
+      kind: 'HttpRoute',
+      pattern: pattern ?? this.stringLiteral('/' + this.rnd('route')),
+      methods: methods ?? [],
+      ...rest,
+    };
+  }
+
+  // 4.1.19 MapKey
+  mapKey(obj?: Override<IR.MapKey>): IR.MapKey {
+    const { value, ...rest } = obj || {};
+
+    return {
+      kind: 'MapKey',
+      value:
+        value ??
+        this.primitiveValue({ typeName: this.primitiveLiteral('string') }),
+      ...rest,
+    };
+  }
+
+  // 4.1.20 MapValue
+  mapValue(obj?: Override<IR.MapValue>): IR.MapValue {
+    const { value, ...rest } = obj || {};
+
+    return {
+      kind: 'MapValue',
+      value:
+        value ??
+        this.primitiveValue({ typeName: this.primitiveLiteral('string') }),
+      ...rest,
+    };
+  }
+
+  // 4.1.24 HttpMethod
+  httpMethod(obj?: Override<IR.HttpMethod>): IR.HttpMethod {
+    const {
+      name,
+      verb,
+      parameters,
+      successCode,
+      requestMediaTypes,
+      responseMediaTypes,
+      ...rest
+    } = obj || {};
+
+    return {
+      kind: 'HttpMethod',
+      name: name ?? this.stringLiteral(this.rnd('httpMethod')),
+      verb: verb ?? this.httpVerbLiteral('post'),
+      parameters: parameters ?? [],
+      successCode: successCode ?? this.httpStatusCodeLiteral(200),
+      requestMediaTypes: requestMediaTypes ?? [
+        this.stringLiteral('application/json'),
+      ],
+      responseMediaTypes: responseMediaTypes ?? [
+        this.stringLiteral('application/json'),
+      ],
+      ...rest,
+    };
+  }
+
+  // 4.1.33 HttpParameter
+  httpParameter(obj?: Override<IR.HttpParameter>): IR.HttpParameter {
+    const { name, location, arrayFormat, ...rest } = obj || {};
+
+    return {
+      kind: 'HttpParameter',
+      name: name ?? this.stringLiteral(this.rnd('param')),
+      location: location ?? this.httpLocationLiteral('query'),
+      arrayFormat: arrayFormat,
+      ...rest,
+    };
+  }
+
+  // 4.2 Validation Rules
+
+  stringMaxLengthRule(length: number): IR.StringMaxLengthRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'StringMaxLength',
+      length: this.nonNegativeIntegerLiteral(length),
+    };
+  }
+
+  stringMinLengthRule(length: number): IR.StringMinLengthRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'StringMinLength',
+      length: this.nonNegativeIntegerLiteral(length),
+    };
+  }
+
+  stringPatternRule(pattern: string): IR.StringPatternRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'StringPattern',
+      pattern: this.nonEmptyStringLiteral(pattern),
+    };
+  }
+
+  stringFormatRule(pattern: string): IR.StringFormatRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'StringFormat',
+      format: this.nonEmptyStringLiteral(pattern),
+    };
+  }
+
+  numberMultipleOfRule(value: number): IR.NumberMultipleOfRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'NumberMultipleOf',
+      value: this.nonNegativeNumberLiteral(value),
+    };
+  }
+
+  numberGtRule(value: number): IR.NumberGtRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'NumberGT',
+      value: this.numberLiteral(value),
+    };
+  }
+
+  numberGteRule(value: number): IR.NumberGteRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'NumberGTE',
+      value: this.numberLiteral(value),
+    };
+  }
+
+  numberLtRule(value: number): IR.NumberLtRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'NumberLT',
+      value: this.numberLiteral(value),
+    };
+  }
+
+  numberLteRule(value: number): IR.NumberLteRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'NumberLTE',
+      value: this.numberLiteral(value),
+    };
+  }
+
+  arrayMaxItemsRule(count: number): IR.ArrayMaxItemsRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'ArrayMaxItems',
+      max: this.nonNegativeIntegerLiteral(count),
+    };
+  }
+
+  arrayMinItemsRule(count: number): IR.ArrayMinItemsRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'ArrayMinItems',
+      min: this.nonNegativeIntegerLiteral(count),
+    };
+  }
+
+  arrayUniqueItemsRule(): IR.ArrayUniqueItemsRule {
+    return {
+      kind: 'ValidationRule',
+      id: 'ArrayUniqueItems',
+      required: true,
+    };
+  }
+
+  // 4.3 Object Rules
+
+  // 4.3.1 ObjectMinPropertiesRule
+  objectMinPropertiesRule(count: number): IR.ObjectMinPropertiesRule {
+    return {
+      kind: 'ObjectValidationRule',
+      id: 'ObjectMinProperties',
+      min: this.nonNegativeIntegerLiteral(count),
+    };
+  }
+
+  // 4.3.2 ObjectMaxPropertiesRule
+  objectMaxPropertiesRule(count: number): IR.ObjectMaxPropertiesRule {
+    return {
+      kind: 'ObjectValidationRule',
+      id: 'ObjectMaxProperties',
+      max: this.nonNegativeIntegerLiteral(count),
+    };
+  }
+
+  // 4.3.3 ObjectNoAdditionalPropertiesRule
+  objectAdditionalPropertiesRule(): IR.ObjectAdditionalPropertiesRule {
+    return {
+      kind: 'ObjectValidationRule',
+      id: 'ObjectAdditionalProperties',
+      forbidden: this.trueLiteral(),
+    };
+  }
+
+  // 4.4 Literals
+
+  // 4.4.1 StringLiteral
+  stringLiteral(value: string): IR.StringLiteral {
+    return { kind: 'StringLiteral', value };
+  }
+
+  // 4.4.2 IntegerLiteral
+  integerLiteral(value: number): IR.IntegerLiteral {
+    return { kind: 'IntegerLiteral', value };
+  }
+
+  // 4.4.3 TrueLiteral
+  trueLiteral(): IR.TrueLiteral {
+    return { kind: 'TrueLiteral', value: true };
+  }
+
+  // 4.4.4 DisjunctionKindLiteral
+  disjunctionKindLiteral(value: IR.DisjunctionKind): IR.DisjunctionKindLiteral {
+    return { kind: 'DisjunctionKindLiteral', value };
+  }
+
+  // 4.4.5 UntypedLiteral
+  untypedLiteral(value: any): IR.UntypedLiteral {
+    return { kind: 'UntypedLiteral', value };
+  }
+
+  // 4.4.6 NonNegativeIntegerLiteral
+  nonNegativeIntegerLiteral(value: number): IR.NonNegativeIntegerLiteral {
+    return { kind: 'NonNegativeIntegerLiteral', value };
+  }
+
+  // 4.4.7 PrimitiveLiteral
+  primitiveLiteral(value: IR.Primitive): IR.PrimitiveLiteral {
+    return { kind: 'PrimitiveLiteral', value };
+  }
+
+  // 4.4.8 NumberLiteral
+  numberLiteral(value: number): IR.NumberLiteral {
+    return { kind: 'NumberLiteral', value };
+  }
+
+  // 4.4.9 BooleanLiteral
+  booleanLiteral(value: boolean): IR.BooleanLiteral {
+    return { kind: 'BooleanLiteral', value };
+  }
+
+  // 4.4.10 NullLiteral
+  nullLiteral(): IR.NullLiteral {
+    return { kind: 'NullLiteral', value: null };
+  }
+
+  // 4.4.11 NonEmptyStringLiterals
+  nonEmptyStringLiteral(value: string): IR.NonEmptyStringLiteral {
+    return { kind: 'NonEmptyStringLiteral', value };
+  }
+
+  // 4.4.12 NonNegativeNumberLiteral
+  nonNegativeNumberLiteral(value: number): IR.NonNegativeNumberLiteral {
+    return { kind: 'NonNegativeNumberLiteral', value };
+  }
+
+  // 4.4.13 HttpVerbLiteral
+  httpVerbLiteral(value: IR.HttpVerb): IR.HttpVerbLiteral {
+    return { kind: 'HttpVerbLiteral', value };
+  }
+
+  // 4.4.14 HttpStatusCodeLiteral
+  httpStatusCodeLiteral(value: number): IR.HttpStatusCodeLiteral {
+    return { kind: 'HttpStatusCodeLiteral', value };
+  }
+
+  // 4.4.15 HttpLocationLiteral
+  httpLocationLiteral(value: IR.HttpLocation): IR.HttpLocationLiteral {
+    return { kind: 'HttpLocationLiteral', value };
+  }
+
+  // 4.4.16 HttpArrayFormatLiteral
+  httpArrayFormatLiteral(value: IR.HttpArrayFormat): IR.HttpArrayFormatLiteral {
+    return { kind: 'HttpArrayFormatLiteral', value };
+  }
+}

--- a/utils/jest-utils/src/global.d.ts
+++ b/utils/jest-utils/src/global.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toContainAst(expected: string): R | Promise<R>;
+    }
+  }
+}
+export {};

--- a/utils/jest-utils/src/index.ts
+++ b/utils/jest-utils/src/index.ts
@@ -1,0 +1,192 @@
+import * as ts from 'typescript';
+import type { Options } from 'prettier';
+import { format } from '@prettier/sync';
+
+export { Factory } from './factory';
+
+/** Formats a string using Prettier */
+function f(s: string): string {
+  // First pass: format with very tight print width to force line breaks
+  // Second pass: format with normal print width to clean up
+  return format(
+    format(s, {
+      parser: 'typescript',
+      singleQuote: true,
+      trailingComma: 'all',
+      printWidth: 1,
+    }),
+    {
+      parser: 'typescript',
+      singleQuote: true,
+      trailingComma: 'all',
+      printWidth: 80,
+    },
+  );
+}
+
+export function registerJestUtils() {
+  expect.extend({
+    toContainAst(received, expected) {
+      if (typeof received !== 'string') {
+        return {
+          pass: false,
+          message: () =>
+            `toContainAst expected a string as the received value, but got ${typeof received}`,
+        };
+      } else if (typeof expected !== 'string') {
+        return {
+          pass: false,
+          message: () =>
+            `toContainAst expected the 'expected' argument to be a string, but got ${typeof expected}`,
+        };
+      }
+
+      const utils = this.utils;
+
+      const sfExpected = parse(expected, 'expected.ts');
+      const sfReceived = parse(received, 'received.ts');
+
+      const expectedDecls = collectNamedTopDecls(sfExpected);
+      const receivedDecls = collectNamedTopDecls(sfReceived);
+
+      const missing: string[] = [];
+      const mismatched: Array<{
+        key: string;
+        kind: string;
+        name: string;
+        a: string;
+        b: string;
+      }> = [];
+
+      const expectedArr: string[] = [];
+      const actualArr: string[] = [];
+
+      for (const [key, expDecl] of expectedDecls) {
+        const gotDecl = receivedDecls.get(key);
+        const [kind, name] = key.split(':');
+
+        expectedArr.push(`${kind} ${name}`);
+        if (gotDecl) {
+          actualArr.push(`${kind} ${name}`);
+        } else {
+          missing.push(`${kind} ${name}`);
+          continue;
+        }
+        const expPrinted = printNode(sfExpected, expDecl);
+        const gotPrinted = printNode(sfReceived, gotDecl);
+
+        if (expPrinted !== gotPrinted) {
+          const [kind, name] = key.split(':');
+          mismatched.push({ key, kind, name, a: expPrinted, b: gotPrinted });
+        }
+      }
+
+      const pass = missing.length === 0 && mismatched.length === 0;
+
+      return {
+        pass,
+        message: () => {
+          const lines: string[] = [];
+          if (pass) {
+            // If Jest shows message on negated assertion, provide a brief diffy note
+            lines.push(
+              'Expected AST NOT to match, but all expected declarations matched.',
+            );
+          } else {
+            if (missing.length) {
+              const expectedString = expectedArr.sort().join('\n');
+              const actualString = actualArr.sort().join('\n');
+
+              lines.push('Missing declarations');
+              for (const k of missing) lines.push(`  - ${k}`);
+              lines.push('');
+              const diff =
+                utils.diff(expectedString, actualString) ??
+                `${expectedString}\n\nvs\n\n${actualString}`;
+              lines.push(diff);
+              lines.push('');
+            }
+            for (const m of mismatched) {
+              lines.push(`Mismatched ${m.kind} declaration for '${m.name}':`);
+              const diff = utils.diff(m.a, m.b) ?? `${m.a}\n\nvs\n\n${m.b}`;
+              lines.push(diff);
+              lines.push('');
+            }
+            // Optional: when nothing matched at all, offer a hint
+            if (expectedDecls.size && receivedDecls.size === 0) {
+              lines.push(
+                "Hint: No named top-level declarations were found in 'received'. " +
+                  'Did the generator wrap output (e.g., namespace/module) or emit only statements without names?',
+              );
+            }
+          }
+          return lines.join('\n');
+        },
+      };
+    },
+  });
+}
+
+type NamedTopDecl =
+  | ts.InterfaceDeclaration
+  | ts.TypeAliasDeclaration
+  | ts.ClassDeclaration
+  | ts.EnumDeclaration
+  | ts.FunctionDeclaration
+  | ts.VariableStatement;
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+function parse(code: string, fileName = 'virtual.ts'): ts.SourceFile {
+  return ts.createSourceFile(
+    fileName,
+    code,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function printNode(sf: ts.SourceFile, node: ts.Node): string {
+  return f(printer.printNode(ts.EmitHint.Unspecified, node, sf).trim());
+}
+
+function isNamedTopDecl(n: ts.Node): n is NamedTopDecl {
+  return (
+    (ts.isInterfaceDeclaration(n) && !!n.name) ||
+    (ts.isTypeAliasDeclaration(n) && !!n.name) ||
+    (ts.isClassDeclaration(n) && !!n.name) ||
+    (ts.isEnumDeclaration(n) && !!n.name) ||
+    (ts.isFunctionDeclaration(n) && !!n.name) ||
+    (ts.isVariableStatement(n) &&
+      n.declarationList.declarations.some(
+        (d) => ts.isIdentifier(d.name) && !!d.name,
+      ))
+  );
+}
+
+function kindLabel(n: NamedTopDecl): string {
+  if (ts.isInterfaceDeclaration(n)) return 'interface';
+  if (ts.isTypeAliasDeclaration(n)) return 'type';
+  if (ts.isClassDeclaration(n)) return 'class';
+  if (ts.isEnumDeclaration(n)) return 'enum';
+  if (ts.isFunctionDeclaration(n)) return 'function';
+  if (ts.isVariableStatement(n)) return 'const';
+  return 'decl';
+}
+
+function keyFor(n: NamedTopDecl): string {
+  // key used to match across files: "<kind>:<name>"
+  const name = ts.isVariableStatement(n)
+    ? n.declarationList.declarations[0].name.getText()
+    : n.name!.text;
+  return `${kindLabel(n)}:${name}`;
+}
+
+function collectNamedTopDecls(sf: ts.SourceFile): Map<string, NamedTopDecl> {
+  const map = new Map<string, NamedTopDecl>();
+  for (const stmt of sf.statements) {
+    if (isNamedTopDecl(stmt)) map.set(keyFor(stmt), stmt);
+  }
+  return map;
+}

--- a/utils/jest-utils/src/setup.ts
+++ b/utils/jest-utils/src/setup.ts
@@ -1,0 +1,5 @@
+import { registerJestUtils } from '.';
+
+registerJestUtils();
+
+export {};

--- a/utils/jest-utils/tsconfig.json
+++ b/utils/jest-utils/tsconfig.json
@@ -8,7 +8,8 @@
     "declaration": true,
     "strictNullChecks": true,
     "downlevelIteration": true,
-    "types": ["@basketry/jest-utils/src/global.d.ts", "jest"]
+    "outDir": "lib"
   },
+  "include": ["src"],
   "exclude": ["**/*.test?.*"]
 }


### PR DESCRIPTION
This PR introduces AST-based testing for TypeScript generators by creating a new `jest-utils` workspace with custom Jest matchers. The main goal is to enable testing of generated TypeScript code by parsing and comparing Abstract Syntax Trees (ASTs) rather than relying on string comparisons.

Key changes:

- New jest-utils package with AST parsing and comparison functionality
- Custom Jest matcher `toContainAst` for comparing generated code against expected AST structures
- Factory class for creating test data using Basketry IR types
- Demonstrate test suite migration from snapshot- to AST-based assertions